### PR TITLE
Mirror mode bug fixes

### DIFF
--- a/Variants/InvertHorizontalControls.cs
+++ b/Variants/InvertHorizontalControls.cs
@@ -1,43 +1,58 @@
 ﻿using Celeste;
 using MonoMod.RuntimeDetour;
+using MonoMod.Utils;
 using System;
 using static ExtendedVariants.Module.ExtendedVariantsModule;
 
-namespace ExtendedVariants.Variants {
-    public class InvertHorizontalControls : AbstractExtendedVariant {
+namespace ExtendedVariants.Variants
+{
+    public class InvertHorizontalControls : AbstractExtendedVariant
+    {
 
-        public override Type GetVariantType() {
+        public override Type GetVariantType()
+        {
             return typeof(bool);
         }
 
-        public override object GetDefaultVariantValue() {
+        public override object GetDefaultVariantValue()
+        {
             return false;
         }
 
-        public override object ConvertLegacyVariantValue(int value) {
+        public override object ConvertLegacyVariantValue(int value)
+        {
             return value != 0;
         }
 
-        public override void Load() {
-            using (new DetourContext {
+        public override void Load()
+        {
+            using (new DetourContext
+            {
                 After = { "*" } // we want to be extra sure we're applied after Crow Control here.
-            }) {
+            })
+            {
                 On.Celeste.Level.Update += onLevelUpdate;
             }
         }
 
-        public override void Unload() {
+        public override void Unload()
+        {
             On.Celeste.Level.Update -= onLevelUpdate;
         }
 
-        private void onLevelUpdate(On.Celeste.Level.orig_Update orig, Level self) {
-            if (Input.Aim == null || Input.MoveX == null || SaveData.Instance?.Assists == null) {
+        private void onLevelUpdate(On.Celeste.Level.orig_Update orig, Level self)
+        {
+            if (Input.Aim == null || Input.MoveX == null || SaveData.Instance?.Assists == null)
+            {
                 orig(self);
                 return;
             }
 
+            bool isMirrorModeActive = GetVariantValue<bool>(Variant.MirrorMode) || SaveData.Instance.Assists.MirrorMode;
+            bool isInvertHorizontalControlsActive = GetVariantValue<bool>(Variant.InvertHorizontalControls);
+
             // this is vanilla behavior
-            Input.Aim.InvertedX = SaveData.Instance.Assists.MirrorMode;
+            Input.Aim.InvertedX = isMirrorModeActive;
 
             // there may be Crow Control here. if so, it will mess with Input.Aim.InvertedX
             orig(self);
@@ -45,8 +60,7 @@ namespace ExtendedVariants.Variants {
             // at this point, Input.Aim.InvertedX is either the vanilla value, or what Crow Control wants.
             // either way, we should keep it or invert it based on our settings.
 
-            bool expectedValue = Input.Aim.InvertedX;
-            if (GetVariantValue<bool>(Variant.InvertHorizontalControls)) expectedValue = !expectedValue;
+            bool expectedValue = Input.Aim.InvertedX ^ isInvertHorizontalControlsActive;
 
             Input.Aim.InvertedX = expectedValue;
             Input.MoveX.Inverted = expectedValue;

--- a/Variants/Vanilla/MirrorMode.cs
+++ b/Variants/Vanilla/MirrorMode.cs
@@ -1,28 +1,71 @@
 ﻿using Celeste;
+using ExtendedVariants.Module;
 using System;
 
-namespace ExtendedVariants.Variants.Vanilla {
-    public class MirrorMode : AbstractVanillaVariant {
-        public override Type GetVariantType() {
+namespace ExtendedVariants.Variants.Vanilla
+{
+    public class MirrorMode : AbstractVanillaVariant
+    {
+        public override Type GetVariantType()
+        {
             return typeof(bool);
         }
 
-        public override object GetDefaultVariantValue() {
+        public override object GetDefaultVariantValue()
+        {
             return false;
         }
 
-        public override object ConvertLegacyVariantValue(int value) {
+        public override void Load()
+        {
+            On.Celeste.Level.BeforeRender += Level_BeforeRender;
+            On.Celeste.Level.AfterRender += Level_AfterRender;
+        }
+
+        public override void Unload()
+        {
+            On.Celeste.Level.BeforeRender -= Level_BeforeRender;
+            On.Celeste.Level.AfterRender -= Level_AfterRender;
+        }
+
+        public override object ConvertLegacyVariantValue(int value)
+        {
             return value != 0;
         }
 
-        public override void VariantValueChanged() {
+        public override void VariantValueChanged()
+        {
             bool mirrorMode = getActiveAssistValues().MirrorMode;
             Input.MoveX.Inverted = (Input.Aim.InvertedX = (Input.Feather.InvertedX = mirrorMode));
         }
 
-        protected override Assists applyVariantValue(Assists target, object value) {
-            target.MirrorMode = (bool) value;
+        protected override Assists applyVariantValue(Assists target, object value)
+        {
+            target.MirrorMode = (bool)value;
             return target;
+        }
+
+
+        private static bool previousMirrorModeValue;
+
+        private static void Level_BeforeRender(On.Celeste.Level.orig_BeforeRender orig, Level self)
+        {
+            // Some entities CoreMessage for example checks for MirrorMode in there render function, 
+            // we need to ensure that even if we have a level specific MirrorMode they still render correctly
+            previousMirrorModeValue = SaveData.Instance.Assists.MirrorMode;
+            bool isMirrorModeActive = (bool)ExtendedVariantsModule.Instance.TriggerManager.GetCurrentVariantValue(ExtendedVariantsModule.Variant.MirrorMode)
+                                      || SaveData.Instance.Assists.MirrorMode;
+
+            SaveData.Instance.Assists.MirrorMode = isMirrorModeActive;
+
+            orig(self);
+        }
+
+        private static void Level_AfterRender(On.Celeste.Level.orig_AfterRender orig, Level self)
+        {
+            SaveData.Instance.Assists.MirrorMode = previousMirrorModeValue;
+
+            orig(self);
         }
     }
 }


### PR DESCRIPTION
This PR fixes 2 issues with mirror mode

1. currently toggling `MirrorMode` from a `BooleanVanillaVariantTrigger` reverses the X axis inputs, this is caused due to `InvertHorizontalControls` not testing if a Revert On Death variant is active.
2. Then the second issue is with entities that use `SaveData.Instance.Assists.MirrorMode` to render themself, again if we toggle the variant until death we get buggy visuals, so I added a before & after render hooks to lie to those entities by overriding `SaveData.Instance.Assists.MirrorMode` before call ( not sure if its an elegant solution ).