### PR TITLE
fix PlayAsBadeline not reverting after first death

### DIFF
--- a/Variants/Vanilla/PlayAsBadeline.cs
+++ b/Variants/Vanilla/PlayAsBadeline.cs
@@ -1,38 +1,74 @@
 ﻿using Celeste;
+using Celeste.Mod;
+using ExtendedVariants.Module;
 using Monocle;
 using System;
 
-namespace ExtendedVariants.Variants.Vanilla {
-    public class PlayAsBadeline : AbstractVanillaVariant {
-        public override Type GetVariantType() {
+namespace ExtendedVariants.Variants.Vanilla
+{
+    public class PlayAsBadeline : AbstractVanillaVariant
+    {
+        public override Type GetVariantType()
+        {
             return typeof(bool);
         }
 
-        public override object GetDefaultVariantValue() {
+        public override object GetDefaultVariantValue()
+        {
             return false;
         }
 
-        public override object ConvertLegacyVariantValue(int value) {
+        public override object ConvertLegacyVariantValue(int value)
+        {
             return value != 0;
         }
 
-        public override void VariantValueChanged() {
-            bool playAsBadeline = getActiveAssistValues().PlayAsBadeline;
-
-            Player player = Engine.Scene?.Tracker.GetEntity<Player>();
-            if (player != null) {
-                PlayerSpriteMode mode = (playAsBadeline ? PlayerSpriteMode.MadelineAsBadeline : player.DefaultSpriteMode);
-                if (player.Active) {
-                    player.ResetSpriteNextFrame(mode);
-                } else {
-                    player.ResetSprite(mode);
-                }
+        public static void ChangePlayerSprite(Player player, bool playAsBadeline)
+        {
+            PlayerSpriteMode mode = playAsBadeline ? PlayerSpriteMode.MadelineAsBadeline : player.DefaultSpriteMode;
+            if (player.Active)
+            {
+                player.ResetSpriteNextFrame(mode);
+            }
+            else
+            {
+                player.ResetSprite(mode);
             }
         }
 
-        protected override Assists applyVariantValue(Assists target, object value) {
-            target.PlayAsBadeline = (bool) value;
+        public override void VariantValueChanged()
+        {
+            bool playAsBadeline = getActiveAssistValues().PlayAsBadeline;
+            Player player = Engine.Scene?.Tracker.GetEntity<Player>();
+
+            if (player != null)
+            {
+                ChangePlayerSprite(player, playAsBadeline);
+            }
+        }
+
+        protected override Assists applyVariantValue(Assists target, object value)
+        {
+            target.PlayAsBadeline = (bool)value;
             return target;
         }
+
+
+        public override void Load()
+        {
+            Everest.Events.Player.OnSpawn += Player_OnSpawn;
+        }
+
+        public override void Unload()
+        {
+            Everest.Events.Player.OnSpawn -= Player_OnSpawn;
+        }
+
+        private static void Player_OnSpawn(Player player)
+        {
+            bool playAsBadeline = (bool)ExtendedVariantsModule.Instance.TriggerManager.GetCurrentVariantValue(ExtendedVariantsModule.Variant.PlayAsBadeline);
+            ChangePlayerSprite(player, playAsBadeline);
+        }
+
     }
 }


### PR DESCRIPTION
If `PlayAsBadeline` is set until death and the player dies their sprite won't revert back to normal until they dies again afterwards.
This is caused because the variant is reset on player constructor, but it the player isn't present in the level yet.