### PR TITLE
"Preserve Extra Dashes Underwater": Decrease dashes to 0 if `PlayerInventory.NoRefills` is set

### DIFF
--- a/Variants/PreserveExtraDashesUnderwater.cs
+++ b/Variants/PreserveExtraDashesUnderwater.cs
@@ -28,8 +28,12 @@ namespace ExtendedVariants.Variants {
         private int onSwimUpdate(On.Celeste.Player.orig_SwimUpdate orig, Player self) {
             int result = orig(self);
 
-            if (!GetVariantValue<bool>(Variant.PreserveExtraDashesUnderwater) && result == Player.StDash && self.Dashes > self.MaxDashes) {
-                // if we're dashing and have more than our dash count, consume a dash!
+            if (!GetVariantValue<bool>(Variant.PreserveExtraDashesUnderwater)
+                    && result == Player.StDash
+                    && (self.Dashes > self.MaxDashes || (self.Inventory.NoRefills && self.Dashes > 0))) {
+                // consume a dash, if we're dashing and...
+                // - have more than our dash count
+                // - core mode is enabled and we have dashes
                 self.Dashes--;
             }
 


### PR DESCRIPTION
###### *[Context](https://discord.com/channels/403698615446536203/1167188337493278771) (original suggestion in the Official Celeste Discord server)*

Updated the "Preserve Extra Dashes Underwater" variant to decrement dashes to 0 if `PlayerInventory.NoRefills` is set.