### PR TITLE
Prevent climb hopping if it would reduce the current jump refills

### DIFF
--- a/Variants/JumpCount.cs
+++ b/Variants/JumpCount.cs
@@ -48,6 +48,7 @@ namespace ExtendedVariants.Variants {
             IL.Celeste.Player.DashUpdate += patchJumpGraceTimer;
             IL.Celeste.Player.UseRefill += modUseRefill;
             On.Celeste.Player.DreamDashEnd += modDreamDashEnd;
+            On.Celeste.Player.ClimbHopBlockedCheck += modClimbHopBlockedCheck;
             On.Celeste.Level.LoadLevel += modLoadLevel;
             IL.Celeste.Player.DreamDashUpdate += preventDreamJumping;
 
@@ -63,6 +64,7 @@ namespace ExtendedVariants.Variants {
             IL.Celeste.Player.DashUpdate -= patchJumpGraceTimer;
             IL.Celeste.Player.UseRefill -= modUseRefill;
             On.Celeste.Player.DreamDashEnd -= modDreamDashEnd;
+            On.Celeste.Player.ClimbHopBlockedCheck -= modClimbHopBlockedCheck;
             On.Celeste.Level.LoadLevel -= modLoadLevel;
             IL.Celeste.Player.DreamDashUpdate -= preventDreamJumping;
         }
@@ -256,6 +258,19 @@ namespace ExtendedVariants.Variants {
                 // without this, jumps are only refilled when the coyote jump timer is filled: it only happens on horizontal dream dashes.
                 RefillJumpBuffer();
             }
+        }
+
+        private bool modClimbHopBlockedCheck(On.Celeste.Player.orig_ClimbHopBlockedCheck orig, Player self) {
+            if (orig(self)) {
+                return true;
+            }
+
+            // if landing on the ground would reduce the number of jumps we have, prevent an automatic climb hop
+            if (GetVariantValue<bool>(Variant.ResetJumpCountOnGround) && jumpBuffer > GetVariantValue<int>(Variant.JumpCount) - 1) {
+                return true;
+            }
+
+            return false;
         }
 
         private void modLoadLevel(On.Celeste.Level.orig_LoadLevel orig, Level self, Player.IntroTypes playerIntro, bool isFromLoader) {


### PR DESCRIPTION
I've noticed a lot of new players not understand that jump refills usually reset when landing on the ground.  This is especially frustrating for them when the refill doesn't respawn and they don't know what to do.

This change prevents Madeline from performing a climb hop if she has a jump refill that would reset upon touching ground.  Hopefully this should help new players understand the mechanic and would be less fiddly.

Resolves #20 