### PR TITLE
Add UltraProtection, LiftboostProtection, TrueNoGrabbing, and Bufferable Grab

### DIFF
--- a/Ahorn/libraries/extendedVariantDictionary.jl
+++ b/Ahorn/libraries/extendedVariantDictionary.jl
@@ -73,6 +73,7 @@ const BooleanVariants = [
     "BadelineBossesEverywhere",
     "BadelineChasersEverywhere",
     "BounceEverywhere",
+	"BufferableGrab",
     "ChangePatternsOfExistingBosses",
     "CorrectedMirrorMode",
     "DashTrailAllTheTime",
@@ -100,6 +101,7 @@ const BooleanVariants = [
     "InvertHorizontalControls",
     "InvertVerticalControls",
     "LegacyDashSpeedBehavior",
+	"LiftboostProtection",
     "NoFreezeFrames",
     "OshiroEverywhere",
     "PermanentBinoStorage",
@@ -111,6 +113,8 @@ const BooleanVariants = [
     "RisingLavaEverywhere",
     "SnowballsEverywhere",
     "TheoCrystalsEverywhere",
+	"TrueNoGrabbing",
+	"UltraProtection",
     "UpsideDown"
 ]
 

--- a/Dialog/English.txt
+++ b/Dialog/English.txt
@@ -329,3 +329,12 @@ MODOPTIONS_EXTENDEDVARIANTS_RANDOMIZER_SEEDDESCRIPTION2= the variants will be th
 MODOPTIONS_EXTENDEDVARIANTS_OSD= Variants - In-Game Display
 MODOPTIONS_EXTENDEDVARIANTS_OSD_TEXTOPACITY= Text Opacity
 MODOPTIONS_EXTENDEDVARIANTS_OSD_BGOPACITY= Background Opacity
+
+MODOPTIONS_EXTENDEDVARIANTS_ULTRAPROTECTION=Ultra Protection
+MODOPTIONS_EXTENDEDVARIANTS_ULTRAPROTECTION_HINT=Ensures that the player gains ultra speed even when buffering a jump or dash upon reaching the ground
+MODOPTIONS_EXTENDEDVARIANTS_LIFTBOOSTPROTECTION=Liftboost Protection
+MODOPTIONS_EXTENDEDVARIANTS_LIFTBOOSTPROTECTION_HINT=Ensures that the player gets liftboost when buffering any type of jump off of a moving platform
+MODOPTIONS_EXTENDEDVARIANTS_TRUENOGRABBING=True No Grabbing
+MODOPTIONS_EXTENDEDVARIANTS_TRUENOGRABBING_HINT=Completely disables the grab input check. Useful for maps that repurpose the grab input
+MODOPTIONS_EXTENDEDVARIANTS_BUFFERABLEGRAB=Bufferable Grab
+MODOPTIONS_EXTENDEDVARIANTS_BUFFERABLEGRAB_HINT=Makes the grab input bufferable, for maps that introduce a new action when pressing grab

--- a/Loenn/triggers/booleanExtendedVariantTrigger.lua
+++ b/Loenn/triggers/booleanExtendedVariantTrigger.lua
@@ -29,6 +29,7 @@ trigger.fieldInformation = {
             "BadelineBossesEverywhere",
             "BadelineChasersEverywhere",
             "BounceEverywhere",
+			"BufferableGrab",
             "ChangePatternsOfExistingBosses",
             "CorrectedMirrorMode",
             "DashTrailAllTheTime",
@@ -56,6 +57,7 @@ trigger.fieldInformation = {
             "InvertHorizontalControls",
             "InvertVerticalControls",
             "LegacyDashSpeedBehavior",
+			"LiftboostProtection",
             "NoFreezeFrames",
             "OshiroEverywhere",
             "PermanentBinoStorage",
@@ -67,6 +69,8 @@ trigger.fieldInformation = {
             "RisingLavaEverywhere",
             "SnowballsEverywhere",
             "TheoCrystalsEverywhere",
+			"TrueNoGrabbing",
+			"UltraProtection",
             "UpsideDown"
         },
         editable = false

--- a/Module/ExtendedVariantsModule.cs
+++ b/Module/ExtendedVariantsModule.cs
@@ -57,7 +57,7 @@ namespace ExtendedVariants.Module {
             WallSlidingSpeed, DisableJumpingOutOfWater, DisableDashCooldown, DisableKeysSpotlight, JungleSpidersEverywhere, CornerCorrection, PickupDuration,
             MinimumDelayBeforeThrowing, DelayBeforeRegrabbing, DashTimerMultiplier, JumpDuration, HorizontalSpringBounceDuration, HorizontalWallJumpDuration,
             ResetJumpCountOnGround, UltraSpeedMultiplier, JumpCooldown, SpinnerColor, WallJumpDistance, WallBounceDistance, DashRestriction, CorrectedMirrorMode,
-            FastFallAcceleration, AlwaysFeather, PermanentDashAttack, PermanentBinoStorage,
+            FastFallAcceleration, AlwaysFeather, PermanentDashAttack, PermanentBinoStorage, UltraProtection, LiftboostProtection, TrueNoGrabbing, BufferableGrab,
 
             // vanilla variants
             AirDashes, DashAssist, VanillaGameSpeed, Hiccups, InfiniteStamina, Invincible, InvisibleMotion, LowFriction, MirrorMode, NoGrabbing, PlayAsBadeline,
@@ -195,6 +195,10 @@ namespace ExtendedVariants.Module {
             VariantHandlers[Variant.AlwaysFeather] = new AlwaysFeather();
             VariantHandlers[Variant.PermanentDashAttack] = new PermanentDashAttack();
             VariantHandlers[Variant.PermanentBinoStorage] = new PermanentBinoStorage();
+            VariantHandlers[Variant.UltraProtection] = new UltraProtection();
+            VariantHandlers[Variant.LiftboostProtection] = new LiftboostProtection();
+            VariantHandlers[Variant.TrueNoGrabbing] = new TrueNoGrabbing();
+            VariantHandlers[Variant.BufferableGrab] = new BufferableGrab();
 
             // vanilla variants
             VariantHandlers[Variant.AirDashes] = new AirDashes();

--- a/UI/ModOptionsEntries.cs
+++ b/UI/ModOptionsEntries.cs
@@ -287,7 +287,7 @@ namespace ExtendedVariants.UI {
                     Variant.WallSlidingSpeed, Variant.DisableJumpingOutOfWater, Variant.DisableDashCooldown, Variant.CornerCorrection, Variant.PickupDuration, Variant.MinimumDelayBeforeThrowing,
                     Variant.DelayBeforeRegrabbing, Variant.DashTimerMultiplier, Variant.JumpDuration, Variant.HorizontalWallJumpDuration, Variant.HorizontalSpringBounceDuration,
                     Variant.ResetJumpCountOnGround, Variant.UltraSpeedMultiplier, Variant.DashDirection, Variant.JumpCooldown, Variant.WallJumpDistance, Variant.WallBounceDistance,
-                    Variant.FastFallAcceleration,
+                    Variant.FastFallAcceleration, Variant.UltraProtection, Variant.LiftboostProtection, Variant.TrueNoGrabbing, Variant.BufferableGrab
                 });
 
                 gameElementsSubmenu.GetHighlightColor = () => getColorForVariantSubmenu(new List<Variant> {
@@ -482,6 +482,11 @@ namespace ExtendedVariants.UI {
                     i => Dialog.Clean("MODOPTIONS_EXTENDEDVARIANTS_DISABLECLIMBINGUPORDOWN_" + i)));
                 menu.Add(getScaleOption(Variant.HorizontalSpringBounceDuration, "x", multiplierScale));
                 menu.Add(getScaleOption(Variant.FastFallAcceleration, "x", multiplierScale));
+
+                menu.Add(getToggleOption(Variant.UltraProtection));
+                menu.Add(getToggleOption(Variant.LiftboostProtection));
+                menu.Add(getToggleOption(Variant.TrueNoGrabbing));
+                menu.Add(getToggleOption(Variant.BufferableGrab));
 
                 menu.Add(buildHeading(menu, "HOLDABLES"));
                 menu.Add(getScaleOption(Variant.PickupDuration, "x", multiplierScale));

--- a/Variants/BufferableGrab.cs
+++ b/Variants/BufferableGrab.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Celeste;
+using ExtendedVariants.Module;
+using Monocle;
+
+namespace ExtendedVariants.Variants; 
+
+public class BufferableGrab : AbstractExtendedVariant {
+    public override void Load() => On.Celeste.Player.Added += Player_Added;
+
+    public override void Unload() => On.Celeste.Player.Added -= Player_Added;
+
+    public override Type GetVariantType() => typeof(bool);
+
+    public override object GetDefaultVariantValue() => false;
+
+    public override object ConvertLegacyVariantValue(int value) => value != 0;
+    
+    public override void VariantValueChanged() => UpdateBuffer();
+
+    private void UpdateBuffer() => Input.Grab.BufferTime = GetVariantValue<bool>(ExtendedVariantsModule.Variant.BufferableGrab) ? 0.08f : 0f;
+    
+    private void Player_Added(On.Celeste.Player.orig_Added added, Player player, Scene scene) {
+        added(player, scene);
+        UpdateBuffer();
+    }
+}

--- a/Variants/LiftboostProtection.cs
+++ b/Variants/LiftboostProtection.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using Celeste;
+using Celeste.Mod;
+using ExtendedVariants.Module;
+using Microsoft.Xna.Framework;
+using Mono.Cecil.Cil;
+using MonoMod.Cil;
+
+namespace ExtendedVariants.Variants; 
+
+public class LiftboostProtection : AbstractExtendedVariant {
+    public override void Load() {
+        On.Celeste.Player.Jump += Player_Jump;
+        On.Celeste.Player.SuperJump += Player_SuperJump;
+        On.Celeste.Player.SuperWallJump += Player_SuperWallJump;
+        IL.Celeste.Platform.Update += Platform_Update_il;
+        IL.Celeste.Platform.MoveH_float += PatchLiftboostProtectionX;
+        IL.Celeste.Platform.MoveH_float_float += PatchLiftboostProtectionX;
+        IL.Celeste.Platform.MoveV_float += PatchLiftboostProtectionY;
+        IL.Celeste.Platform.MoveV_float_float += PatchLiftboostProtectionY;
+        IL.Celeste.Platform.MoveHNaive += PatchLiftboostProtectionX;
+        IL.Celeste.Platform.MoveVNaive += PatchLiftboostProtectionY;
+        IL.Celeste.Platform.MoveHCollideSolids += PatchLiftboostProtectionX;
+        IL.Celeste.Platform.MoveVCollideSolids += PatchLiftboostProtectionY;
+        IL.Celeste.Platform.MoveHCollideSolidsAndBounds += PatchLiftboostProtectionX;
+        IL.Celeste.Platform.MoveVCollideSolidsAndBounds_Level_float_bool_Action3 += PatchLiftboostProtectionY;
+    }
+
+    public override void Unload() {
+        On.Celeste.Player.Jump -= Player_Jump;
+        On.Celeste.Player.SuperJump -= Player_SuperJump;
+        On.Celeste.Player.SuperWallJump -= Player_SuperWallJump;
+        IL.Celeste.Platform.Update -= Platform_Update_il;
+        IL.Celeste.Platform.MoveH_float -= PatchLiftboostProtectionX;
+        IL.Celeste.Platform.MoveH_float_float -= PatchLiftboostProtectionX;
+        IL.Celeste.Platform.MoveV_float -= PatchLiftboostProtectionY;
+        IL.Celeste.Platform.MoveV_float_float -= PatchLiftboostProtectionY;
+        IL.Celeste.Platform.MoveHNaive -= PatchLiftboostProtectionX;
+        IL.Celeste.Platform.MoveVNaive -= PatchLiftboostProtectionY;
+        IL.Celeste.Platform.MoveHCollideSolids -= PatchLiftboostProtectionX;
+        IL.Celeste.Platform.MoveVCollideSolids -= PatchLiftboostProtectionY;
+        IL.Celeste.Platform.MoveHCollideSolidsAndBounds -= PatchLiftboostProtectionX;
+        IL.Celeste.Platform.MoveVCollideSolidsAndBounds_Level_float_bool_Action3 -= PatchLiftboostProtectionY;
+    }
+
+    public override Type GetVariantType() => typeof(bool);
+
+    public override object GetDefaultVariantValue() => false;
+
+    public override object ConvertLegacyVariantValue(int value) => value != 0;
+    
+    private static void CheckForLiftboost(Player player, Vector2 dir) {
+        if (player.LiftSpeed != Vector2.Zero)
+            return;
+
+        Platform platform;
+        
+        if (dir.X == 0f && dir.Y > 0f)
+            platform = player.CollideFirst<Platform>(player.Position + dir);
+        else
+            platform = player.CollideFirst<Solid>(player.Position + dir);
+
+        if (platform != null)
+            player.LiftSpeed = platform.LiftSpeed;
+    }
+    
+    private void Player_Jump(On.Celeste.Player.orig_Jump jump, Player player, bool particles, bool playsfx) {
+        if (GetVariantValue<bool>(ExtendedVariantsModule.Variant.LiftboostProtection))
+            CheckForLiftboost(player, Vector2.UnitY);
+        
+        jump(player, particles, playsfx);
+    }
+    
+    private void Player_SuperJump(On.Celeste.Player.orig_SuperJump superJump, Player player) {
+        if (GetVariantValue<bool>(ExtendedVariantsModule.Variant.LiftboostProtection))
+            CheckForLiftboost(player, Vector2.UnitY);
+        
+        superJump(player);
+    }
+    
+    private void Player_SuperWallJump(On.Celeste.Player.orig_SuperWallJump superWallJump, Player player, int dir) {
+        if (GetVariantValue<bool>(ExtendedVariantsModule.Variant.LiftboostProtection))
+            CheckForLiftboost(player, -5 * dir * Vector2.UnitX);
+        
+        superWallJump(player, dir);
+    }
+
+    private void Platform_Update_il(ILContext il) {
+        var cursor = new ILCursor(il);
+
+        cursor.Emit(OpCodes.Ldarg_0);
+        cursor.EmitDelegate<Action<Platform>>(platform => {
+            if (GetVariantValue<bool>(ExtendedVariantsModule.Variant.LiftboostProtection))
+                platform.LiftSpeed = Vector2.Zero;
+        });
+
+        cursor.GotoNext(instr => instr.MatchStfld<Platform>("LiftSpeed"));
+
+        cursor.Emit(OpCodes.Ldarg_0);
+        cursor.EmitDelegate<Func<Vector2, Platform, Vector2>>((value, platform)
+            => GetVariantValue<bool>(ExtendedVariantsModule.Variant.LiftboostProtection) ? platform.LiftSpeed : value);
+    }
+
+    private void PatchLiftboostProtectionX(ILContext il) {
+        var cursor = new ILCursor(il);
+
+        while (cursor.TryGotoNext(MoveType.After, instr => instr.MatchLdflda<Platform>("LiftSpeed"))) {
+            cursor.GotoNext(instr => instr.MatchStfld<Vector2>("X"));
+
+            cursor.Emit(OpCodes.Ldarg_0);
+            cursor.EmitDelegate<Func<float, Platform, float>>((value, platform)
+                => GetVariantValue<bool>(ExtendedVariantsModule.Variant.LiftboostProtection) && value == 0f ? platform.LiftSpeed.X : value);
+        }
+    }
+    
+    private void PatchLiftboostProtectionY(ILContext il) {
+        var cursor = new ILCursor(il);
+
+        while (cursor.TryGotoNext(MoveType.After, instr => instr.MatchLdflda<Platform>("LiftSpeed"))) {
+            cursor.GotoNext(instr => instr.MatchStfld<Vector2>("Y"));
+
+            cursor.Emit(OpCodes.Ldarg_0);
+            cursor.EmitDelegate<Func<float, Platform, float>>((value, platform)
+                => GetVariantValue<bool>(ExtendedVariantsModule.Variant.LiftboostProtection) && value == 0f ? platform.LiftSpeed.Y : value);
+        }
+    }
+}

--- a/Variants/TrueNoGrabbing.cs
+++ b/Variants/TrueNoGrabbing.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Reflection;
+using Celeste;
+using ExtendedVariants.Module;
+using MonoMod.RuntimeDetour;
+
+namespace ExtendedVariants.Variants; 
+
+public class TrueNoGrabbing : AbstractExtendedVariant {
+    private IDetour Celeste_Input_get_GrabCheck;
+    
+    public override void Load() => Celeste_Input_get_GrabCheck = new Hook(typeof(Input).GetProperty("GrabCheck", BindingFlags.Public | BindingFlags.Static).GetGetMethod(), Input_get_GrabCheck);
+
+    public override void Unload() => Celeste_Input_get_GrabCheck.Dispose();
+
+    public override Type GetVariantType() => typeof(bool);
+
+    public override object GetDefaultVariantValue() => false;
+
+    public override object ConvertLegacyVariantValue(int value) => value != 0;
+
+    private bool Input_get_GrabCheck(Func<bool> grabCheck) => !GetVariantValue<bool>(ExtendedVariantsModule.Variant.TrueNoGrabbing) && grabCheck();
+}

--- a/Variants/UltraProtection.cs
+++ b/Variants/UltraProtection.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Celeste;
+using ExtendedVariants.Module;
+using MonoMod.Utils;
+
+namespace ExtendedVariants.Variants; 
+
+public class UltraProtection : AbstractExtendedVariant {
+    public override void Load() {
+        On.Celeste.Player.Jump += Player_Jump;
+        On.Celeste.Player.DashBegin += Player_DashBegin;
+    }
+
+    public override void Unload() {
+        On.Celeste.Player.Jump -= Player_Jump;
+        On.Celeste.Player.DashBegin -= Player_DashBegin;
+    }
+
+    public override Type GetVariantType() => typeof(bool);
+
+    public override object GetDefaultVariantValue() => false;
+
+    public override object ConvertLegacyVariantValue(int value) => value != 0;
+    
+    private void Player_Jump(On.Celeste.Player.orig_Jump jump, Player player, bool particles, bool playsfx) {
+        if (GetVariantValue<bool>(ExtendedVariantsModule.Variant.UltraProtection)
+            && player.DashDir.X != 0f && player.DashDir.Y > 0f && player.Speed.Y > 0f
+            && DynamicData.For(player).Get<bool>("onGround")) {
+            player.DashDir.X = Math.Sign(player.DashDir.X);
+            player.DashDir.Y = 0f;
+            player.Speed.X *= 1.2f;
+        }
+        
+        jump(player, particles, playsfx);
+    }
+    
+    private void Player_DashBegin(On.Celeste.Player.orig_DashBegin dashBegin, Player player) {
+        if (GetVariantValue<bool>(ExtendedVariantsModule.Variant.UltraProtection)
+            && player.DashDir.X != 0f && player.DashDir.Y > 0f && player.Speed.Y > 0f
+            && DynamicData.For(player).Get<bool>("onGround"))
+            player.Speed.X *= 1.2f;
+
+        dashBegin(player);
+    }
+}


### PR DESCRIPTION
Adds 4 new variants, two of which aim to fix inconsistencies in the game's mechanics that result from input buffering, and two of which alter the grab input:

- Ultra Protection: Ensures that the player gains ultra speed even when buffering a jump or dash upon reaching the ground
- Liftboost Protection: Ensures that the player gets liftboost when buffering any type of jump off of a moving platform
- True No Grabbing: Completely disables the grab input check. Useful for maps that repurpose the grab input
- Bufferable Grab: Makes the grab input bufferable, for maps that introduce a new action when pressing grab