### PR TITLE
Do not borrow liftboost from horizontally moving jumpthrus

### DIFF
--- a/Variants/LiftboostProtection.cs
+++ b/Variants/LiftboostProtection.cs
@@ -67,16 +67,24 @@ namespace ExtendedVariants.Variants {
 
         private void Player_Jump(On.Celeste.Player.orig_Jump jump, Player player, bool particles, bool playsfx) {
             if (GetVariantValue<bool>(ExtendedVariantsModule.Variant.LiftboostProtection)
-                && player.LiftSpeed == Vector2.Zero && TryGetPlatform(player, Vector2.UnitY, out var platform))
-                player.LiftSpeed = DynamicData.For(platform).Get<Vector2?>("safeLiftSpeed") ?? Vector2.Zero;
+                && player.LiftSpeed == Vector2.Zero && TryGetPlatform(player, Vector2.UnitY, out var platform)) {
+                var safeLiftSpeed = DynamicData.For(platform).Get<Vector2?>("safeLiftSpeed") ?? Vector2.Zero;
+
+                if (platform is not JumpThru || safeLiftSpeed.Y != 0f)
+                    player.LiftSpeed = safeLiftSpeed;
+            }
 
             jump(player, particles, playsfx);
         }
 
         private void Player_SuperJump(On.Celeste.Player.orig_SuperJump superJump, Player player) {
             if (GetVariantValue<bool>(ExtendedVariantsModule.Variant.LiftboostProtection)
-                && player.LiftSpeed == Vector2.Zero && TryGetPlatform(player, Vector2.UnitY, out var platform))
-                player.LiftSpeed = DynamicData.For(platform).Get<Vector2?>("safeLiftSpeed") ?? Vector2.Zero;
+                && player.LiftSpeed == Vector2.Zero && TryGetPlatform(player, Vector2.UnitY, out var platform)) {
+                var safeLiftSpeed = DynamicData.For(platform).Get<Vector2?>("safeLiftSpeed") ?? Vector2.Zero;
+
+                if (platform is not JumpThru || safeLiftSpeed.Y != 0f)
+                    player.LiftSpeed = safeLiftSpeed;
+            }
 
             superJump(player);
         }

--- a/everest.yaml
+++ b/everest.yaml
@@ -1,5 +1,5 @@
 - Name: ExtendedVariantMode
-  Version: 0.31.2
+  Version: 0.31.3
   DLL: bin/Release/net452/ExtendedVariantMode.dll
   Dependencies:
     - Name: Everest


### PR DESCRIPTION
Ensure that Liftboost Protection does not enable the player to get liftboost from horizontally-moving jump-through platforms