### PR TITLE
Implement death effect colour setting for Theo Crystal

### DIFF
--- a/Entities/ForMappers/ExtendedVariantTheoCrystal.cs
+++ b/Entities/ForMappers/ExtendedVariantTheoCrystal.cs
@@ -3,6 +3,7 @@ using Celeste.Mod;
 using Celeste.Mod.Entities;
 using ExtendedVariants.Module;
 using Microsoft.Xna.Framework;
+using Mono.Cecil.Cil;
 using Monocle;
 using MonoMod.Cil;
 using MonoMod.RuntimeDetour;
@@ -17,11 +18,13 @@ namespace ExtendedVariants.Entities.ForMappers {
 
         public static void Load() {
             hookTheoCrystalCtor = new ILHook(typeof(TheoCrystal).GetMethod("orig_ctor"), modTheoCrystalCtor);
+            IL.Celeste.TheoCrystal.Die += modTheoCrystalDie;
         }
 
         public static void Unload() {
             hookTheoCrystalCtor?.Dispose();
             hookTheoCrystalCtor = null;
+            IL.Celeste.TheoCrystal.Die -= modTheoCrystalDie;
         }
 
         private static void modTheoCrystalCtor(ILContext il) {
@@ -32,11 +35,28 @@ namespace ExtendedVariants.Entities.ForMappers {
             }
         }
 
+        private static void modTheoCrystalDie(ILContext il)
+        {
+            ILCursor cursor = new ILCursor(il);
+            while (cursor.TryGotoNext(MoveType.After, instr => instr.MatchCall<Color>("get_ForestGreen")))
+            {
+                Logger.Log("ExtendedVariantMode/ExtendedVariantTheoCrystal", $"Modding death effect color at {cursor.Index} in IL for TheoCrystal.Die");
+                cursor.Emit(OpCodes.Ldarg_0);
+                cursor.EmitDelegate<Func<Color, TheoCrystal, Color>>(ModDeathEffectColor);
+            }
+            return;
+
+            static Color ModDeathEffectColor(Color orig, TheoCrystal self)
+                => self is ExtendedVariantTheoCrystal crystal ? (crystal.deathEffectColor ?? orig) : orig;
+        }
+
         // true if Theo can be left behind, false if the player is blocked if they leave Theo behind, null if it was spawned through the extended variant
         public bool AllowLeavingBehind { get; private set; } = false;
         public bool SpawnedAsEntity { get; private set; } = false;
 
         private bool forceSpawn = false;
+
+        private Color? deathEffectColor = null;
 
         public static Entity Load(Level level, LevelData levelData, Vector2 offset, EntityData entityData) {
             spritePath = entityData.Attr("sprite", defaultValue: "theo_crystal");
@@ -53,6 +73,10 @@ namespace ExtendedVariants.Entities.ForMappers {
             crystal.SpawnedAsEntity = true;
             crystal.AllowLeavingBehind = entityData.Bool("allowLeavingBehind");
             crystal.forceSpawn = entityData.Bool("forceSpawn");
+
+            if (entityData.Has("deathEffectColor"))
+                crystal.deathEffectColor = entityData.HexColor("deathEffectColor", defaultValue: Color.ForestGreen);
+
             return crystal;
         }
 

--- a/Loenn/entities/extendedVariantTheoCrystal.lua
+++ b/Loenn/entities/extendedVariantTheoCrystal.lua
@@ -4,13 +4,19 @@ local theoCrystal = {}
 
 theoCrystal.name = "ExtendedVariantMode/TheoCrystal"
 theoCrystal.depth = 100
+theoCrystal.fieldInformation = {
+    deathEffectColor = {
+        fieldType = "color"
+    }
+}
 theoCrystal.placements = {
     name = "theo_crystal",
     data = {
         allowThrowingOffscreen = false,
         allowLeavingBehind = false,
         forceSpawn = false,
-        sprite = "theo_crystal"
+        sprite = "theo_crystal",
+        deathEffectColor = "228B22"
     }
 }
 

--- a/Loenn/lang/en_gb.lang
+++ b/Loenn/lang/en_gb.lang
@@ -6,6 +6,7 @@ entities.ExtendedVariantMode/TheoCrystal.attributes.description.allowThrowingOff
 entities.ExtendedVariantMode/TheoCrystal.attributes.description.allowLeavingBehind=Whether the player can leave the room without grabbing Theo.
 entities.ExtendedVariantMode/TheoCrystal.attributes.description.forceSpawn=Forces the Theo Crystal to spawn, even if the player is bringing a Theo Crystal from another room.
 entities.ExtendedVariantMode/TheoCrystal.attributes.description.sprite=The sprite that the Theo Crystal should use, from your map's Sprites.xml.
+entities.ExtendedVariantMode/TheoCrystal.attributes.description.deathEffectColor=The color of the particles that appear when the Theo Crystal dies.
 
 # Extra Jump Refill
 entities.ExtendedVariantMode/ExtraJumpRefill.placements.name.default=Extra Jump Refill


### PR DESCRIPTION
This setting allows customising the colour of the crystal's death effect. Goes well with custom sprites

Resolves #51 