### PR TITLE
small fix for the search input ui

### DIFF
--- a/UI/InputSearchUI.cs
+++ b/UI/InputSearchUI.cs
@@ -72,10 +72,13 @@ namespace ExtendedVariants.UI {
             this.showSearchUI = showSearchUI;
             if (!showSearchUI) return;
 
+            Overworld overworld = Engine.Scene as Overworld;
             // make sure the button is part of the current scene (Level or Overworld)
-            if (Scene != Engine.Scene) Engine.Scene.Add(this);
-
-            Action startSearching = ouiModOptionsAddSearchBox.Invoke(null, new object[] { menu, null }) as Action;
+            if (Scene != Engine.Scene) {
+                Engine.Scene.Add(this);
+                this.overworld = overworld;
+            }
+            Action startSearching = ouiModOptionsAddSearchBox.Invoke(null, new object[] { menu, overworld }) as Action;
             // Remove Celeste.TextMenuExt+SearchToolTip added in the previous line
             menu.Remove(menu.Items[menu.Items.Count - 1]);
 


### PR DESCRIPTION
Fix search input UI always uses the overworld even in the level
Fix search function was expected to correct the overworld camera and prevent camera moving when starting type but actually not
