### PR TITLE
Expose GetJumpCount() to LuaCutscenesUtils

### DIFF
--- a/Module/LuaCutscenesUtils.cs
+++ b/Module/LuaCutscenesUtils.cs
@@ -37,5 +37,10 @@ namespace ExtendedVariants.Module {
         public static void CapJumpCount(int jumpCount) {
             JumpCount.SetJumpCount(jumpCount, cap: true);
         }
+
+        public static int GetJumpCount()
+        {
+            return JumpCount.GetJumpBuffer();
+        }
     }
 }


### PR DESCRIPTION
Self-explanatory. Allows mod devs to change jump count relative to the current jump count, such as addition. Needed for a collab's codemod.