### PR TITLE
Fix NRE when the holdable is not actually being held

### DIFF
--- a/Variants/ConsistentThrowing.cs
+++ b/Variants/ConsistentThrowing.cs
@@ -22,9 +22,9 @@ public class ConsistentThrowing : AbstractExtendedVariant {
     }
 
     private void MakeHoldableOffsetConsistent(On.Celeste.Holdable.orig_Release orig, Holdable self, Vector2 force) {
-        if (GetVariantValue<bool>(ExtendedVariantsModule.Variant.ConsistentThrowing)) {
-            Player holder = self.Holder;
-
+        // some mods call Release even though the entity is not held (like PandoraBox clear pipes when entering them)
+        // so we need to check if self.Holder is not null
+        if (GetVariantValue<bool>(ExtendedVariantsModule.Variant.ConsistentThrowing) && self.Holder is { } holder) {
             Vector2 holdablePosition = holder.Position
                 + DynamicData.For(holder).Get<Vector2>("carryOffset")
                 + Vector2.UnitY * (holder.Sprite.CarryYOffset / holder.Sprite.Scale.Y);


### PR DESCRIPTION
Fixes the `System.NullReferenceException` caused by mods calling `Holdable.Release` even though the holdable is not actually being held (like clear pipes from PandorasBox).