### PR TITLE
Implement Jump Boost variant

### DIFF
--- a/Ahorn/libraries/extendedVariantDictionary.jl
+++ b/Ahorn/libraries/extendedVariantDictionary.jl
@@ -44,6 +44,7 @@ const FloatVariants = [
     "HorizontalSpringBounceDuration",
     "HorizontalWallJumpDuration",
     "HyperdashSpeed",
+    "JumpBoost",
     "JumpCooldown",
     "JumpDuration",
     "JumpHeight",

--- a/Dialog/English.txt
+++ b/Dialog/English.txt
@@ -401,3 +401,7 @@ MODOPTIONS_EXTENDEDVARIANTS_AUTODASH_HINT=Forces Madeline to dash when possible.
 MODOPTIONS_EXTENDEDVARIANTS_CONSISTENTTHROWING=Consistent Throwing
 MODOPTIONS_EXTENDEDVARIANTS_CONSISTENTTHROWING_HINT_1=Ignores the sprite scale factor and removes subpixels from the
 MODOPTIONS_EXTENDEDVARIANTS_CONSISTENTTHROWING_HINT_2=holdable throw position, making throws less inconsistent
+
+MODOPTIONS_EXTENDEDVARIANTS_JUMPBOOST= Jump boost
+MODOPTIONS_EXTENDEDVARIANTS_JUMPBOOST_HINT_1=Modifies the horizontal jump boost you get from
+MODOPTIONS_EXTENDEDVARIANTS_JUMPBOOST_HINT_2=jumping, climbjumping, wallboosting and wallbouncing.

--- a/Loenn/triggers/extendedVariantFadeTrigger.lua
+++ b/Loenn/triggers/extendedVariantFadeTrigger.lua
@@ -41,6 +41,7 @@ trigger.fieldInformation = {
             "HorizontalSpringBounceDuration",
             "HorizontalWallJumpDuration",
             "HyperdashSpeed",
+            "JumpBoost",
             "JumpCooldown",
             "JumpDuration",
             "JumpHeight",

--- a/Loenn/triggers/floatExtendedVariantSliderTrigger.lua
+++ b/Loenn/triggers/floatExtendedVariantSliderTrigger.lua
@@ -39,6 +39,7 @@ trigger.fieldInformation = {
             "HorizontalSpringBounceDuration",
             "HorizontalWallJumpDuration",
             "HyperdashSpeed",
+            "JumpBoost",
             "JumpCooldown",
             "JumpDuration",
             "JumpHeight",

--- a/Loenn/triggers/floatExtendedVariantTrigger.lua
+++ b/Loenn/triggers/floatExtendedVariantTrigger.lua
@@ -46,6 +46,7 @@ trigger.fieldInformation = {
             "HorizontalSpringBounceDuration",
             "HorizontalWallJumpDuration",
             "HyperdashSpeed",
+            "JumpBoost",
             "JumpCooldown",
             "JumpDuration",
             "JumpHeight",

--- a/Module/ILCursorExtensions.cs
+++ b/Module/ILCursorExtensions.cs
@@ -1,0 +1,497 @@
+﻿using Mono.Cecil.Cil;
+using MonoMod.Cil;
+using System;
+using System.Collections.Generic;
+using Celeste.Mod;
+
+// since this is a legacy mod, i need to backport this class from Everest
+namespace ExtendedVariants.Module {
+    public static class ILCursorExtensions {
+        public const int DefaultMaxInstructionSpread = 0x10;
+
+        private const string NextBestFitLogID = $"{nameof(ILCursorExtensions)}/NextBestFit";
+        private const string PrevBestFitLogID = $"{nameof(ILCursorExtensions)}/PrevBestFit";
+
+        private struct Match {
+            public int Start;
+            public int End;
+
+            public Match(int start, int end) {
+                Start = start;
+                End = end;
+            }
+        }
+
+        /// <summary>
+        ///   Go to the next best fit match of a given IL sequence, allowing up to <see cref="DefaultMaxInstructionSpread"/>
+        ///   instructions of tolerance if the instructions are not sequential.<br/>
+        ///   (i.e. if something else hooks the same sequence)
+        /// </summary>
+        ///
+        /// <param name="cursor">
+        ///   The IL cursor to look for a match in.
+        /// </param>
+        /// <param name="moveType">
+        ///   The move type to use.
+        /// </param>
+        /// <param name="predicates">
+        ///   The IL instructions to match against.
+        /// </param>
+        ///
+        /// <exception cref="KeyNotFoundException">
+        ///   A match could not be found.
+        /// </exception>
+        ///
+        /// <remarks>
+        ///   This function picks the next match with the least instruction spread.<br/>
+        ///
+        ///   If there are two matches which have the same spread, pick the closest one.
+        /// </remarks>
+        public static void GotoNextBestFit(this ILCursor cursor, MoveType moveType, params Func<Instruction, bool>[] predicates) {
+            cursor.GotoNextBestFit(moveType, DefaultMaxInstructionSpread, predicates);
+        }
+
+        /// <summary>
+        ///   Go to the next best fit match of a given IL sequence, allowing up to <paramref name="maxInstructionSpread"/>
+        ///   instructions of tolerance if the instructions are not sequential.<br/>
+        ///   (i.e. if something else hooks the same sequence)
+        /// </summary>
+        ///
+        /// <param name="cursor">
+        ///   The IL cursor to look for a match in.
+        /// </param>
+        /// <param name="moveType">
+        ///   The move type to use.
+        /// </param>
+        /// <param name="maxInstructionSpread">
+        ///   The amount of instructions between predicate matches to still consider as a successful match.
+        /// </param>
+        /// <param name="predicates">
+        ///   The IL instructions to match against.
+        /// </param>
+        ///
+        /// <exception cref="KeyNotFoundException">
+        ///   A match could not be found.
+        /// </exception>
+        ///
+        /// <remarks>
+        ///   This function picks the next match with the least instruction spread.<br/>
+        ///
+        ///   If there are two matches which have the same spread, pick the closest one.
+        /// </remarks>
+        public static void GotoNextBestFit(this ILCursor cursor, MoveType moveType, int maxInstructionSpread, params Func<Instruction, bool>[] predicates) {
+            if (!cursor.TryGotoNextBestFit(moveType, maxInstructionSpread, predicates))
+                throw new KeyNotFoundException($"Could not find a matching set of instructions with instruction spread of {maxInstructionSpread}.");
+        }
+
+        /// <summary>
+        ///   Go to the next best fit match of a given IL sequence, allowing up to <c>0x10</c>
+        ///   instructions of tolerance if the instructions are not sequential.<br/>
+        ///   (i.e. if something else hooks the same sequence)
+        /// </summary>
+        ///
+        /// <param name="cursor">
+        ///   The IL cursor to look for a match in.
+        /// </param>
+        /// <param name="moveType">
+        ///   The move type to use.
+        /// </param>
+        /// <param name="predicates">
+        ///   The IL instructions to match against.
+        /// </param>
+        ///
+        /// <remarks>
+        ///   This function picks the next match with the least instruction spread.<br/>
+        ///
+        ///   If there are two matches which have the same spread, pick the closest one.
+        /// </remarks>
+        ///
+        /// <returns>
+        ///   Whether a match has been found, and the cursor has been moved.
+        /// </returns>
+        public static bool TryGotoNextBestFit(this ILCursor cursor, MoveType moveType, params Func<Instruction, bool>[] predicates) {
+            return TryGotoNextBestFit(cursor, moveType, DefaultMaxInstructionSpread, predicates);
+        }
+
+        /// <summary>
+        ///   Go to the next best fit match of a given IL sequence, allowing up to <paramref name="maxInstructionSpread"/>
+        ///   instructions of tolerance if the instructions are not sequential.<br/>
+        ///   (i.e. if something else hooks the same sequence)
+        /// </summary>
+        ///
+        /// <param name="cursor">
+        ///   The IL cursor to look for a match in.
+        /// </param>
+        /// <param name="moveType">
+        ///   The move type to use.
+        /// </param>
+        /// <param name="maxInstructionSpread">
+        ///   The amount of instructions between predicate matches to still consider as a successful match.
+        /// </param>
+        /// <param name="predicates">
+        ///   The IL instructions to match against.
+        /// </param>
+        ///
+        /// <remarks>
+        ///   This function picks the next match with the least instruction spread.<br/>
+        ///
+        ///   If there are two matches which have the same spread, pick the closest one.
+        /// </remarks>
+        ///
+        /// <returns>
+        ///   Whether a match has been found, and the cursor has been moved.
+        /// </returns>
+        public static bool TryGotoNextBestFit(this ILCursor cursor, MoveType moveType, int maxInstructionSpread, params Func<Instruction, bool>[] predicates) {
+            if (predicates.Length == 0)
+                throw new ArgumentException("No predicates given.");
+
+            if (predicates.Length == 1)
+                return cursor.TryGotoNext(moveType, predicates[0]);
+
+            Logger.Log(LogLevel.Debug, NextBestFitLogID, $"Looking for next best fit in {cursor.Context.Method.FullName}.");
+            Logger.Log(LogLevel.Debug, NextBestFitLogID, $"{nameof(ILCursor)}#{cursor.GetHashCode():X8} has initial index 0x{cursor.Index:X4}.");
+
+            List<Match> matchCandidates = new();
+
+            int initialPosition = cursor.Index;
+
+            // go to each instance of the first predicate
+            while (cursor.TryGotoNext(MoveType.Before, predicates[0])) {
+                // remember where we were and move past the match
+                int savedCursorPosition = cursor.Index++;
+
+                // then try to match the rest of the predicates
+                bool matchFound = true;
+                for (int i = 1; i < predicates.Length; i++) {
+                    Func<Instruction, bool> matcher = predicates[i];
+                    int beforeMoveIndex = cursor.Index;
+
+                    if (!cursor.TryGotoNext(MoveType.After, matcher)) {
+                        Logger.Log(LogLevel.Verbose, NextBestFitLogID,
+                            $"Matched predicate #0 at index 0x{savedCursorPosition:X4}, but failed to match predicate #{i}. Continuing search.");
+
+                        matchFound = false;
+                        break;
+                    }
+
+                    // also make sure we haven't gone further than maxInstructionSpread
+                    int instructionSpread = cursor.Index - beforeMoveIndex;
+                    if (instructionSpread > maxInstructionSpread) {
+                        Logger.Log(LogLevel.Debug, NextBestFitLogID,
+                            $"Matched predicate #0 at index 0x{savedCursorPosition:X4}, but the instruction spread between predicates #{i-1} and #{i} has been exceeded " +
+                            $"({instructionSpread} > {maxInstructionSpread}). Continuing search.");
+
+                        matchFound = false;
+                        break;
+                    }
+                }
+
+                if (matchFound) {
+                    Logger.Log(LogLevel.Verbose, NextBestFitLogID,
+                        $"Found match between indices 0x{savedCursorPosition:X4} and 0x{cursor.Index:X4}. Continuing search.");
+
+                    // remember the start and end indices of the match
+                    matchCandidates.Add(new Match(savedCursorPosition, cursor.Index));
+                }
+
+                // we go again
+                // skip the first instance, else we'll get stuck
+                cursor.Index = savedCursorPosition + 1;
+            }
+
+            // put the cursor back to where it was
+            cursor.Index = initialPosition;
+
+            if (matchCandidates.Count == 0) {
+                // no match :c
+                Logger.Log(LogLevel.Debug, NextBestFitLogID, $"Could not find next best fit for cursor {nameof(ILCursor)}#{cursor.GetHashCode():X8}.");
+                return false;
+            }
+
+            // we found a match!
+            // pick the one which has the least instruction spread
+
+            Match bestMatch = matchCandidates[0];
+            matchCandidates.RemoveAt(0);
+            int bestMatchDiff = bestMatch.End - bestMatch.Start;
+
+            foreach (Match matchCandidate in matchCandidates) {
+                int matchCandidateDiff = matchCandidate.End - matchCandidate.Start;
+
+                switch (matchCandidateDiff - bestMatchDiff) {
+                    // we found a new best candidate
+                    case < 0:
+
+                    // we found two identical matches; pick the nearest one
+                    case 0 when GetIndexFromMatch(moveType, matchCandidate) - cursor.Index < GetIndexFromMatch(moveType, bestMatch) - cursor.Index:
+                        bestMatch = matchCandidate;
+                        bestMatchDiff = matchCandidateDiff;
+                        break;
+                }
+            }
+
+            Logger.Log(LogLevel.Debug, NextBestFitLogID,
+                $"Selecting next best fit between indices 0x{bestMatch.Start:X4} and 0x{bestMatch.End:X4} for cursor {nameof(ILCursor)}#{cursor.GetHashCode():X8}.");
+
+            // some predicates may be using out parameters; invoke the predicates again to make sure
+            // that the out parameters are set to ones from the match
+            cursor.Index = bestMatch.Start;
+            foreach (Func<Instruction, bool> predicate in predicates)
+                cursor.GotoNext(predicate);
+
+            // and finally move the cursor to the correct place
+            cursor.Index = GetIndexFromMatch(moveType, bestMatch);
+
+            if (moveType is MoveType.AfterLabel)
+                cursor.MoveAfterLabels();
+
+            return true;
+        }
+
+        /// <summary>
+        ///   Go to the previous best fit match of a given IL sequence, allowing up to <see cref="DefaultMaxInstructionSpread"/>
+        ///   instructions of tolerance if the instructions are not sequential.<br/>
+        ///   (i.e. if something else hooks the same sequence)
+        /// </summary>
+        ///
+        /// <param name="cursor">
+        ///   The IL cursor to look for a match in.
+        /// </param>
+        /// <param name="moveType">
+        ///   The move type to use.
+        /// </param>
+        /// <param name="predicates">
+        ///   The IL instructions to match against.
+        /// </param>
+        ///
+        /// <exception cref="KeyNotFoundException">
+        ///   A match could not be found.
+        /// </exception>
+        ///
+        /// <remarks>
+        ///   This function picks the previous match with the least instruction spread.<br/>
+        ///
+        ///   If there are two matches which have the same spread, pick the closest one.<br/>
+        ///
+        ///   If <paramref name="moveType"/> is set to <see cref="MoveType.After"/>, the resulting index
+        ///   <b>may</b> have moved forwards instead of backwards, if the first predicate matches close to the cursor,
+        ///   and the <paramref name="predicates"/> list is long enough.
+        /// </remarks>
+        public static void GotoPrevBestFit(this ILCursor cursor, MoveType moveType, params Func<Instruction, bool>[] predicates) {
+            cursor.GotoPrevBestFit(moveType, DefaultMaxInstructionSpread, predicates);
+        }
+
+        /// <summary>
+        ///   Go to the previous best fit match of a given IL sequence, allowing up to <paramref name="maxInstructionSpread"/>
+        ///   instructions of tolerance if the instructions are not sequential.<br/>
+        ///   (i.e. if something else hooks the same sequence)
+        /// </summary>
+        ///
+        /// <param name="cursor">
+        ///   The IL cursor to look for a match in.
+        /// </param>
+        /// <param name="moveType">
+        ///   The move type to use.
+        /// </param>
+        /// <param name="maxInstructionSpread">
+        ///   The amount of instructions between predicate matches to still consider as a successful match.
+        /// </param>
+        /// <param name="predicates">
+        ///   The IL instructions to match against.
+        /// </param>
+        ///
+        /// <exception cref="KeyNotFoundException">
+        ///   A match could not be found.
+        /// </exception>
+        ///
+        /// <remarks>
+        ///   This function picks the previous match with the least instruction spread.<br/>
+        ///
+        ///   If there are two matches which have the same spread, pick the closest one.<br/>
+        ///
+        ///   If <paramref name="moveType"/> is set to <see cref="MoveType.After"/>, the resulting index
+        ///   <b>may</b> have moved forwards instead of backwards, if the first predicate matches close to the cursor,
+        ///   and the <paramref name="predicates"/> list is long enough.
+        /// </remarks>
+        public static void GotoPrevBestFit(this ILCursor cursor, MoveType moveType, int maxInstructionSpread, params Func<Instruction, bool>[] predicates) {
+            if (!cursor.TryGotoPrevBestFit(moveType, maxInstructionSpread, predicates))
+                throw new KeyNotFoundException($"Could not find a matching set of instructions with instruction spread of {maxInstructionSpread}.");
+        }
+
+        /// <summary>
+        ///   Go to the previous best fit match of a given IL sequence, allowing up to <c>0x10</c>
+        ///   instructions of tolerance if the instructions are not sequential.<br/>
+        ///   (i.e. if something else hooks the same sequence)
+        /// </summary>
+        ///
+        /// <param name="cursor">
+        ///   The IL cursor to look for a match in.
+        /// </param>
+        /// <param name="moveType">
+        ///   The move type to use.
+        /// </param>
+        /// <param name="predicates">
+        ///   The IL instructions to match against.
+        /// </param>
+        ///
+        /// <remarks>
+        ///   This function picks the previous match with the least instruction spread.<br/>
+        ///
+        ///   If there are two matches which have the same spread, pick the closest one.<br/>
+        ///
+        ///   If <paramref name="moveType"/> is set to <see cref="MoveType.After"/>, the resulting index
+        ///   <b>may</b> have moved forwards instead of backwards, if the first predicate matches close to the cursor,
+        ///   and the <paramref name="predicates"/> list is long enough.
+        /// </remarks>
+        ///
+        /// <returns>
+        ///   Whether a match has been found, and the cursor has been moved.
+        /// </returns>
+        public static bool TryGotoPrevBestFit(this ILCursor cursor, MoveType moveType, params Func<Instruction, bool>[] predicates) {
+            return TryGotoPrevBestFit(cursor, moveType, DefaultMaxInstructionSpread, predicates);
+        }
+
+        /// <summary>
+        ///   Go to the previous best fit match of a given IL sequence, allowing up to <paramref name="maxInstructionSpread"/>
+        ///   instructions of tolerance if the instructions are not sequential.<br/>
+        ///   (i.e. if something else hooks the same sequence)
+        /// </summary>
+        ///
+        /// <param name="cursor">
+        ///   The IL cursor to look for a match in.
+        /// </param>
+        /// <param name="moveType">
+        ///   The move type to use.
+        /// </param>
+        /// <param name="maxInstructionSpread">
+        ///   The amount of instructions between predicate matches to still consider as a successful match.
+        /// </param>
+        /// <param name="predicates">
+        ///   The IL instructions to match against.
+        /// </param>
+        ///
+        /// <remarks>
+        ///   This function picks the previous match with the least instruction spread.<br/>
+        ///
+        ///   If there are two matches which have the same spread, pick the closest one.<br/>
+        ///
+        ///   If <paramref name="moveType"/> is set to <see cref="MoveType.After"/>, the resulting index
+        ///   <b>may</b> have moved forwards instead of backwards, if the first predicate matches close to the cursor,
+        ///   and the <paramref name="predicates"/> list is long enough.
+        /// </remarks>
+        ///
+        /// <returns>
+        ///   Whether a match has been found, and the cursor has been moved.
+        /// </returns>
+        public static bool TryGotoPrevBestFit(this ILCursor cursor, MoveType moveType, int maxInstructionSpread, params Func<Instruction, bool>[] predicates) {
+            if (predicates.Length == 0)
+                throw new ArgumentException("No predicates given.");
+
+            if (predicates.Length == 1)
+                return cursor.TryGotoNext(moveType, predicates[0]);
+
+            Logger.Log(LogLevel.Debug, PrevBestFitLogID, $"Looking for previous best fit in {cursor.Context.Method.FullName}.");
+            Logger.Log(LogLevel.Debug, PrevBestFitLogID, $"{nameof(ILCursor)}#{cursor.GetHashCode():X8} has initial index 0x{cursor.Index:X4}.");
+
+            List<Match> matchCandidates = new();
+
+            int initialPosition = cursor.Index;
+
+            // go to each instance of the first predicate
+            while (cursor.TryGotoPrev(MoveType.Before, predicates[0])) {
+                // remember where we were and move past the match
+                int savedCursorPosition = cursor.Index++;
+
+                // then try to match the rest of the predicates
+                bool matchFound = true;
+                for (int i = 1; i < predicates.Length; i++) {
+                    Func<Instruction, bool> matcher = predicates[i];
+                    int beforeMoveIndex = cursor.Index;
+
+                    if (!cursor.TryGotoNext(MoveType.After, matcher)) {
+                        Logger.Log(LogLevel.Verbose, PrevBestFitLogID,
+                            $"Matched predicate #0 at index 0x{savedCursorPosition:X4}, but failed to match predicate #{i}. Continuing search.");
+
+                        matchFound = false;
+                        break;
+                    }
+
+                    // also make sure we haven't gone further than maxInstructionSpread
+                    // note that we could have gone past the initial cursor position!
+                    int instructionSpread = cursor.Index - beforeMoveIndex;
+                    if (instructionSpread > maxInstructionSpread) {
+                        Logger.Log(LogLevel.Debug, PrevBestFitLogID,
+                            $"Matched predicate #0 at index 0x{savedCursorPosition:X4}, but the instruction spread between predicates #{i-1} and #{i} has been exceeded " +
+                            $"({instructionSpread} > {maxInstructionSpread}). Continuing search.");
+
+                        matchFound = false;
+                        break;
+                    }
+                }
+
+                if (matchFound) {
+                    Logger.Log(LogLevel.Verbose, PrevBestFitLogID,
+                        $"Found match between indices 0x{savedCursorPosition:X4} and 0x{cursor.Index:X4}. Continuing search.");
+
+                    // remember the start and end indices of the match
+                    matchCandidates.Add(new Match(savedCursorPosition, cursor.Index));
+                }
+
+                // we go again
+                cursor.Index = savedCursorPosition;
+            }
+
+            // put the cursor back to where it was
+            cursor.Index = initialPosition;
+
+            if (matchCandidates.Count == 0) {
+                // no match :c
+                Logger.Log(LogLevel.Debug, PrevBestFitLogID, $"Could not find previous best fit for cursor {nameof(ILCursor)}#{cursor.GetHashCode():X8}.");
+                return false;
+            }
+
+            // we found a match!
+            // pick the one which has the least instruction spread
+
+            Match bestMatch = matchCandidates[0];
+            matchCandidates.RemoveAt(0);
+            int bestMatchDiff = bestMatch.End - bestMatch.Start;
+
+            foreach (Match matchCandidate in matchCandidates) {
+                int matchCandidateDiff = matchCandidate.End - matchCandidate.Start;
+
+                switch (matchCandidateDiff - bestMatchDiff) {
+                    // we found a new best candidate
+                    case < 0:
+
+                    // we found two identical matches; pick the nearest one
+                    case 0 when cursor.Index - GetIndexFromMatch(moveType, matchCandidate) < cursor.Index - GetIndexFromMatch(moveType, bestMatch):
+                        bestMatch = matchCandidate;
+                        bestMatchDiff = matchCandidateDiff;
+                        break;
+                }
+            }
+
+            Logger.Log(LogLevel.Debug, PrevBestFitLogID,
+                $"Selecting previous best fit between indices 0x{bestMatch.Start:X4} and 0x{bestMatch.End:X4} for cursor {nameof(ILCursor)}#{cursor.GetHashCode():X8}.");
+
+            // some predicates may be using out parameters; invoke them again to make sure
+            // that the out parameters are set to ones from the match
+            cursor.Index = bestMatch.Start;
+            foreach (Func<Instruction, bool> predicate in predicates)
+                cursor.GotoNext(predicate);
+
+            // and finally move the cursor to the correct place
+            cursor.Index = GetIndexFromMatch(moveType, bestMatch);
+
+            if (moveType is MoveType.AfterLabel)
+                cursor.MoveAfterLabels();
+
+            return true;
+        }
+
+        private static int GetIndexFromMatch(MoveType moveType, Match match) {
+            return moveType == MoveType.After ? match.End : match.Start;
+        }
+    }
+}

--- a/UI/ModOptionsEntries.cs
+++ b/UI/ModOptionsEntries.cs
@@ -315,7 +315,7 @@ namespace ExtendedVariants.UI {
                     Variant.JumpDuration, Variant.HorizontalWallJumpDuration, Variant.HorizontalSpringBounceDuration, Variant.ResetJumpCountOnGround, Variant.UltraSpeedMultiplier,
                     Variant.DashDirection, Variant.JumpCooldown, Variant.WallJumpDistance, Variant.WallBounceDistance, Variant.FastFallAcceleration, Variant.TrueNoGrabbing,
                     Variant.WalllessWallbounce, Variant.MidairTech, Variant.PreserveWallbounceSpeed, Variant.StretchUpDashes, Variant.DisableJumpGravityLowering, Variant.DisableAutoJumpGravityLowering,
-                    Variant.SlowfallGravityMultiplier, Variant.SlowfallSpeedThreshold
+                    Variant.SlowfallGravityMultiplier, Variant.SlowfallSpeedThreshold, Variant.JumpBoost
                 });
 
                 gameElementsSubmenu.GetHighlightColor = () => getColorForVariantSubmenu(new List<Variant> {
@@ -364,6 +364,12 @@ namespace ExtendedVariants.UI {
 
                 menu.Add(buildHeading(menu, "JUMPING"));
                 menu.Add(getScaleOption(Variant.JumpHeight, "x", multiplierScale));
+
+                TextMenuOptionExt<int> jumpBoostOption;
+                menu.Add(jumpBoostOption = getScaleOption(Variant.JumpBoost, "x", multiplierScaleWithNegatives));
+                jumpBoostOption.AddDescription(menu, Dialog.Clean("MODOPTIONS_EXTENDEDVARIANTS_JUMPBOOST_HINT_2"));
+                jumpBoostOption.AddDescription(menu, Dialog.Clean("MODOPTIONS_EXTENDEDVARIANTS_JUMPBOOST_HINT_1"));
+
                 menu.Add(getScaleOption(Variant.JumpDuration, "x", multiplierScale));
                 menu.Add(getScaleOption(Variant.WallBouncingSpeed, "x", multiplierScale));
                 menu.Add(getToggleOption(Variant.DisableWallJumping));

--- a/Variants/JumpBoost.cs
+++ b/Variants/JumpBoost.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Reflection;
+using Celeste;
+using ExtendedVariants.Module;
+using Mono.Cecil.Cil;
+using MonoMod.Cil;
+using MonoMod.RuntimeDetour;
+
+namespace ExtendedVariants.Variants;
+
+public class JumpBoost : AbstractExtendedVariant {
+    private const float JumpHBoost = 40f;
+    private const float WallJumpHSpeed = Player.MaxRun + JumpHBoost;
+    private const float SuperWallJumpH = Player.MaxRun + JumpHBoost * 2;
+
+    public JumpBoost() : base(typeof(float), 1f) { }
+
+    public override object ConvertLegacyVariantValue(int value) {
+        return value / 10f;
+    }
+
+    private ILHook Player_orig_WallJump;
+    private ILHook Player_orig_Update;
+
+    public override void Load() {
+        IL.Celeste.Player.HiccupJump += ChangeJumpHBoost;
+        IL.Celeste.Player.Jump += ChangeJumpHBoost;
+
+        Player_orig_WallJump = new ILHook(
+            typeof(Player).GetMethod("orig_WallJump", BindingFlags.NonPublic | BindingFlags.Instance),
+            ChangeWallJumpHSpeed);
+        Player_orig_Update = new ILHook(
+            typeof(Player).GetMethod("orig_Update"),
+            ChangeWallJumpHSpeedInUpdate);
+
+        IL.Celeste.Player.SuperWallJump += ChangeSuperWallJumpH;
+    }
+
+    public override void Unload() {
+        IL.Celeste.Player.HiccupJump -= ChangeJumpHBoost;
+        IL.Celeste.Player.Jump -= ChangeJumpHBoost;
+
+        Player_orig_WallJump?.Dispose();
+        Player_orig_Update?.Dispose();
+
+        IL.Celeste.Player.SuperWallJump -= ChangeSuperWallJumpH;
+    }
+
+    private void ChangeJumpHBoost(ILContext il) {
+        ILCursor cursor = new(il);
+
+        // hELPER emits some il in Player.Jump which also puts a ldc.r4 40. we need to change all of those +40s.
+        while (cursor.TryGotoNextBestFit(MoveType.Before,
+            static instr => instr.MatchLdcR4(JumpHBoost),
+            static instr => instr.MatchLdarg(0),
+            static instr => instr.MatchLdfld<Player>("moveX"),
+            static instr => instr.MatchConvR4(),
+            static instr => instr.MatchMul())) {
+            // we're guaranteed to be before the ldc.r4 40
+            cursor.Index++;
+            cursor.EmitDelegate<Func<float, float>>(ApplyJumpHBoostMultiplier);
+        }
+    }
+
+    private void ChangeWallJumpHSpeed(ILContext il) {
+        ILCursor cursor = new(il);
+
+        while (cursor.TryGotoNextBestFit(MoveType.Before,
+            static instr => instr.MatchLdcR4(WallJumpHSpeed),
+            static instr => instr.MatchLdarg(1),
+            static instr => instr.MatchConvR4(),
+            static instr => instr.MatchMul())) {
+            // we're guaranteed to be before the ldc.r4 130
+            cursor.Index++;
+            cursor.EmitDelegate<Func<float, float>>(ApplyWallJumpHSpeedMultiplier);
+        }
+    }
+
+    private void ChangeWallJumpHSpeedInUpdate(ILContext il) {
+        ILCursor cursor = new(il);
+
+        // this code handles wallboosts so we need to also affect that
+        while (cursor.TryGotoNextBestFit(MoveType.Before,
+            static instr => instr.MatchLdcR4(WallJumpHSpeed),
+            static instr => instr.MatchLdarg(0),
+            static instr => instr.MatchLdfld<Player>("moveX"),
+            static instr => instr.MatchConvR4(),
+            static instr => instr.MatchMul())) {
+            // we're guaranteed to be before the ldc.r4 130
+            cursor.Index++;
+            cursor.EmitDelegate<Func<float, float>>(ApplyWallJumpHSpeedMultiplier);
+        }
+    }
+
+    private void ChangeSuperWallJumpH(ILContext il) {
+        ILCursor cursor = new(il);
+
+        while (cursor.TryGotoNextBestFit(MoveType.Before,
+            static instr => instr.MatchLdcR4(SuperWallJumpH),
+            static instr => instr.MatchLdarg(1),
+            static instr => instr.MatchConvR4(),
+            static instr => instr.MatchMul())) {
+            // we're guaranteed to be before the ldc.r4 170
+            cursor.Index++;
+            cursor.EmitDelegate<Func<float, float>>(ApplySuperWallJumpHMultiplier);
+        }
+    }
+
+    private float ApplyJumpHBoostMultiplier(float orig) {
+        return orig * GetVariantValue<float>(ExtendedVariantsModule.Variant.JumpBoost);
+    }
+
+    private float ApplyWallJumpHSpeedMultiplier(float orig) {
+        // orig already contains JumpHBoost
+        return orig + JumpHBoost * (GetVariantValue<float>(ExtendedVariantsModule.Variant.JumpBoost) - 1);
+    }
+
+    private float ApplySuperWallJumpHMultiplier(float orig) {
+        // orig already contains JumpHBoost * 2
+        return orig + 2 * JumpHBoost * (GetVariantValue<float>(ExtendedVariantsModule.Variant.JumpBoost) - 1);
+    }
+}

--- a/Variants/StretchUpDashes.cs
+++ b/Variants/StretchUpDashes.cs
@@ -7,6 +7,7 @@ using MonoMod.RuntimeDetour;
 using MonoMod.Utils;
 using System;
 using System.Reflection;
+using ExtendedVariants.Module;
 using static ExtendedVariants.Module.ExtendedVariantsModule;
 
 namespace ExtendedVariants.Variants {
@@ -35,7 +36,7 @@ namespace ExtendedVariants.Variants {
                 static instr => instr.MatchStfld<Vector2>("X")
             };
 
-            if (!TryGotoNextBestFit(cursor, MoveType.After, ilSequence)) {
+            if (!cursor.TryGotoNextBestFit(MoveType.After, ilSequence)) {
                 Logger.Log(LogLevel.Error, "ExtendedVariantMode/StretchUpDashes",
                     $"Could not find IL sequence to hook in {il.Method.FullName}!");
                 return;

--- a/Variants/UnderwaterXSpeed.cs
+++ b/Variants/UnderwaterXSpeed.cs
@@ -2,6 +2,7 @@
 using Mono.Cecil.Cil;
 using MonoMod.Cil;
 using System;
+using ExtendedVariants.Module;
 using static ExtendedVariants.Module.ExtendedVariantsModule;
 
 namespace ExtendedVariants.Variants {
@@ -41,7 +42,7 @@ namespace ExtendedVariants.Variants {
             }
 
             ILCursor xIfCheck = ySpeedVariable.Clone();
-            if (!TryGotoNextBestFit(xIfCheck, MoveType.Before,
+            if (!xIfCheck.TryGotoNextBestFit(MoveType.Before,
                 static instr => instr.MatchLdcR4(SlowerDecelerationSpeedThreshold),
                 static instr => instr.MatchBleUn(out _)))
             {
@@ -52,7 +53,7 @@ namespace ExtendedVariants.Variants {
             xIfCheck.Index++;
 
             ILCursor yIfCheck = xIfCheck.Clone();
-            if (!TryGotoNextBestFit(yIfCheck, MoveType.Before,
+            if (!yIfCheck.TryGotoNextBestFit(MoveType.Before,
                 static instr => instr.MatchLdcR4(SlowerDecelerationSpeedThreshold),
                 static instr => instr.MatchBleUn(out _)))
             {


### PR DESCRIPTION
Allows players to modify the `JumpHBoost` constant by a multiplier (based on Noel's `Player.cs`).
It also backports Everest's `ILCursorExtensions` class so that it's available for other variants to use.