### PR TITLE
Internal seeding

### DIFF
--- a/Ahorn/libraries/extendedVariantDictionary.jl
+++ b/Ahorn/libraries/extendedVariantDictionary.jl
@@ -7,6 +7,7 @@ const IntegerVariants = [
     "BadelineBossCount",
     "BadelineBossNodeCount",
     "ChaserCount",
+    "SetSeed",
     "CornerCorrection",
     "DashCount",
     "JellyfishEverywhere",

--- a/Module/ExtendedVariantsModule.cs
+++ b/Module/ExtendedVariantsModule.cs
@@ -71,7 +71,7 @@ namespace ExtendedVariants.Module {
             CornerboostProtection, CrouchDashFix, AlternativeBuffering, MultiBuffering, SaferDiagonalSmuggle, DashBeforePickup, ThrowIgnoresForcedMove, DashbounceControl, MidairTech,
             NoFreezeFramesAdvanceCassetteBlocks, PreserveWallbounceSpeed, StretchUpDashes, DisableJumpGravityLowering, DisableAutoJumpGravityLowering, UnderwaterSpeedX, UnderwaterSpeedY,
             WaterSurfaceSpeedX, WaterSurfaceSpeedY, LiftboostCapX, LiftboostCapUp, LiftboostCapDown, AutoJump, SlowfallGravityMultiplier, SlowfallSpeedThreshold, AutoDash,
-            ConsistentThrowing, JumpBoost,
+            ConsistentThrowing, JumpBoost, SetSeed,
             ClimbUpSpeed, ClimbDownSpeed, ClimbJumpStaminaCost, ClimbUpStaminaDrainRate, ClimbHoldStaminaDrainRate, HarmlessSeekers, MuteSeekerSounds,
 
             // vanilla variants
@@ -126,6 +126,7 @@ namespace ExtendedVariants.Module {
             VariantHandlers[Variant.DisableNeutralJumping] = new DisableNeutralJumping();
             VariantHandlers[Variant.BadelineChasersEverywhere] = new BadelineChasersEverywhere();
             VariantHandlers[Variant.ChaserCount] = new ChaserCount();
+            VariantHandlers[Variant.SetSeed] = new SetSeed();
             VariantHandlers[Variant.AffectExistingChasers] = new AffectExistingChasers();
             VariantHandlers[Variant.BadelineBossesEverywhere] = new BadelineBossesEverywhere();
             VariantHandlers[Variant.BadelineAttackPattern] = new BadelineAttackPattern();

--- a/UI/ModOptionsEntries.cs
+++ b/UI/ModOptionsEntries.cs
@@ -350,7 +350,7 @@ namespace ExtendedVariants.UI {
 
                 qualityOfLifeSubmenu.GetHighlightColor = () => getColorForVariantSubmenu(new List<Variant> {
                     Variant.UltraProtection, Variant.LiftboostProtection, Variant.CornerboostProtection, Variant.CrouchDashFix, Variant.AlternativeBuffering, Variant.ConsistentThrowing,
-                    Variant.MultiBuffering, Variant.SaferDiagonalSmuggle, Variant.DashBeforePickup, Variant.DashbounceControl, Variant.ThrowIgnoresForcedMove, Variant.SetSeed
+                    Variant.MultiBuffering, Variant.SaferDiagonalSmuggle, Variant.DashBeforePickup, Variant.DashbounceControl, Variant.ThrowIgnoresForcedMove
                 });
 
                 elementsToHideOnToggle = new List<TextMenu.Item>() { resetVanillaVariants, resetExtendedVariants, title, movementSubmenu, gameElementsSubmenu, visualSubmenu, gameplayTweaksSubmenu, qualityOfLifeSubmenu };

--- a/UI/ModOptionsEntries.cs
+++ b/UI/ModOptionsEntries.cs
@@ -350,7 +350,7 @@ namespace ExtendedVariants.UI {
 
                 qualityOfLifeSubmenu.GetHighlightColor = () => getColorForVariantSubmenu(new List<Variant> {
                     Variant.UltraProtection, Variant.LiftboostProtection, Variant.CornerboostProtection, Variant.CrouchDashFix, Variant.AlternativeBuffering, Variant.ConsistentThrowing,
-                    Variant.MultiBuffering, Variant.SaferDiagonalSmuggle, Variant.DashBeforePickup, Variant.DashbounceControl, Variant.ThrowIgnoresForcedMove
+                    Variant.MultiBuffering, Variant.SaferDiagonalSmuggle, Variant.DashBeforePickup, Variant.DashbounceControl, Variant.ThrowIgnoresForcedMove, Variant.SetSeed
                 });
 
                 elementsToHideOnToggle = new List<TextMenu.Item>() { resetVanillaVariants, resetExtendedVariants, title, movementSubmenu, gameElementsSubmenu, visualSubmenu, gameplayTweaksSubmenu, qualityOfLifeSubmenu };

--- a/Variants/AddSeekers.cs
+++ b/Variants/AddSeekers.cs
@@ -35,8 +35,6 @@ namespace ExtendedVariants.Variants {
         }
 
         public override void Load() {
-            // Everest.Events.Level.OnLoadLevel += setRNGSeed;
-            // Everest.Events.Level.OnEnter += setRNGSeed;
             Everest.Events.AssetReload.OnBeforeReload+= setRNGSeed;
             On.Celeste.Level.LoadLevel += modLoadLevel;
             IL.Celeste.SeekerEffectsController.Update += onSeekerEffectsControllerUpdate;

--- a/Variants/AddSeekers.cs
+++ b/Variants/AddSeekers.cs
@@ -35,7 +35,6 @@ namespace ExtendedVariants.Variants {
         }
 
         public override void Load() {
-            // Set the RNG at the beginning of a level
             Everest.Events.LevelLoader.OnLoadingThread += setRNGSeed;
             On.Celeste.Level.LoadLevel += modLoadLevel;
             IL.Celeste.SeekerEffectsController.Update += onSeekerEffectsControllerUpdate;
@@ -56,6 +55,7 @@ namespace ExtendedVariants.Variants {
 
             killSeekerSlowdownToFixHeart = false;
         }
+
         private void setRNGSeed(Level level) {
             int seed = GetVariantValue<int>(Variant.SetSeed);
             SetRandomSeed(seed);

--- a/Variants/AddSeekers.cs
+++ b/Variants/AddSeekers.cs
@@ -16,7 +16,6 @@ namespace ExtendedVariants.Variants {
     public class AddSeekers : AbstractExtendedVariant {
 
         private static Random randomGenerator = new Random();
-        
 
         private static bool killSeekerSlowdownToFixHeart = false;
         private static string calcLogPrefix = null;
@@ -31,7 +30,7 @@ namespace ExtendedVariants.Variants {
         }
 
         public override void SetRandomSeed(int seed) {
-            Calc.PushRandom(seed);
+            randomGenerator = new Random(seed);
         }
 
         public override void Load() {
@@ -97,8 +96,8 @@ namespace ExtendedVariants.Variants {
 
                     for (int i = 0; i < 100; i++) {
                         // roll a seeker position in the room
-                        int x = Calc.Random.Next(level.Bounds.Width) + level.Bounds.X;
-                        int y = Calc.Random.Next(level.Bounds.Height) + level.Bounds.Y;
+                        int x = randomGenerator.Next(level.Bounds.Width) + level.Bounds.X;
+                        int y = randomGenerator.Next(level.Bounds.Height) + level.Bounds.Y;
 
                         // should be at least 100 pixels from the player
                         double playerDistance = Math.Sqrt(Math.Pow(MathHelper.Distance(x, player.X), 2) + Math.Pow(MathHelper.Distance(y, player.Y), 2));

--- a/Variants/AddSeekers.cs
+++ b/Variants/AddSeekers.cs
@@ -16,6 +16,7 @@ namespace ExtendedVariants.Variants {
     public class AddSeekers : AbstractExtendedVariant {
 
         private static Random randomGenerator = new Random();
+        
 
         private static bool killSeekerSlowdownToFixHeart = false;
         private static string calcLogPrefix = null;
@@ -34,6 +35,9 @@ namespace ExtendedVariants.Variants {
         }
 
         public override void Load() {
+            // Everest.Events.Level.OnLoadLevel += setRNGSeed;
+            // Everest.Events.Level.OnEnter += setRNGSeed;
+            Everest.Events.AssetReload.OnBeforeReload+= setRNGSeed;
             On.Celeste.Level.LoadLevel += modLoadLevel;
             IL.Celeste.SeekerEffectsController.Update += onSeekerEffectsControllerUpdate;
             On.Celeste.HeartGem.Collect += onHeartGemCollect;
@@ -53,7 +57,10 @@ namespace ExtendedVariants.Variants {
 
             killSeekerSlowdownToFixHeart = false;
         }
-
+        private void setRNGSeed(bool silent) {
+            int seed = GetVariantValue<int>(Variant.SetSeed);
+            SetRandomSeed(seed);
+        }
         private static void modLoadLevel(On.Celeste.Level.orig_LoadLevel orig, Level self, Player.IntroTypes playerIntro, bool isFromLoader) {
             orig(self, playerIntro, isFromLoader);
 

--- a/Variants/AddSeekers.cs
+++ b/Variants/AddSeekers.cs
@@ -35,7 +35,8 @@ namespace ExtendedVariants.Variants {
         }
 
         public override void Load() {
-            Everest.Events.AssetReload.OnBeforeReload+= setRNGSeed;
+            // Set the RNG at the beginning of a level
+            Everest.Events.LevelLoader.OnLoadingThread += setRNGSeed;
             On.Celeste.Level.LoadLevel += modLoadLevel;
             IL.Celeste.SeekerEffectsController.Update += onSeekerEffectsControllerUpdate;
             On.Celeste.HeartGem.Collect += onHeartGemCollect;
@@ -55,7 +56,7 @@ namespace ExtendedVariants.Variants {
 
             killSeekerSlowdownToFixHeart = false;
         }
-        private void setRNGSeed(bool silent) {
+        private void setRNGSeed(Level level) {
             int seed = GetVariantValue<int>(Variant.SetSeed);
             SetRandomSeed(seed);
         }

--- a/Variants/BadelineBossesEverywhere.cs
+++ b/Variants/BadelineBossesEverywhere.cs
@@ -33,7 +33,6 @@ namespace ExtendedVariants.Variants {
             On.Celeste.Level.LoadLevel += modLoadLevel;
             On.Celeste.Level.TransitionRoutine += modTransitionRoutine;
             IL.Celeste.FinalBoss.ctor_Vector2_Vector2Array_int_float_bool_bool_bool += modBadelineBossConstructor;
-            SetRandomSeed(GetVariantValue<int>(Variant.SetSeed));
         }
 
         public override void Unload() {
@@ -43,7 +42,7 @@ namespace ExtendedVariants.Variants {
             IL.Celeste.FinalBoss.ctor_Vector2_Vector2Array_int_float_bool_bool_bool -= modBadelineBossConstructor;
         }
 
-        private void setRNGSeed(bool silent) {
+        private void setRNGSeed(Level level) {
             int seed = GetVariantValue<int>(Variant.SetSeed);
             SetRandomSeed(seed);
         }

--- a/Variants/BadelineBossesEverywhere.cs
+++ b/Variants/BadelineBossesEverywhere.cs
@@ -13,6 +13,8 @@ using static ExtendedVariants.Module.ExtendedVariantsModule;
 namespace ExtendedVariants.Variants {
     public class BadelineBossesEverywhere : AbstractExtendedVariant {
 
+        private static Random randomGenerator = new Random();
+
         public BadelineBossesEverywhere() : base(variantType: typeof(bool), defaultVariantValue: false) { }
 
         public override object ConvertLegacyVariantValue(int value) {
@@ -20,7 +22,7 @@ namespace ExtendedVariants.Variants {
         }
 
         public override void SetRandomSeed(int seed) {
-            Calc.PushRandom(seed);
+            randomGenerator = new Random(seed);
         }
 
         public override void Load() {

--- a/Variants/BadelineBossesEverywhere.cs
+++ b/Variants/BadelineBossesEverywhere.cs
@@ -28,7 +28,7 @@ namespace ExtendedVariants.Variants {
         }
 
         public override void Load() {
-            Everest.Events.AssetReload.OnBeforeReload+= setRNGSeed;
+            Everest.Events.LevelLoader.OnLoadingThread += setRNGSeed;
             IL.Celeste.FinalBoss.CanChangeMusic += modCanChangeMusic;
             On.Celeste.Level.LoadLevel += modLoadLevel;
             On.Celeste.Level.TransitionRoutine += modTransitionRoutine;

--- a/Variants/BadelineBossesEverywhere.cs
+++ b/Variants/BadelineBossesEverywhere.cs
@@ -28,10 +28,12 @@ namespace ExtendedVariants.Variants {
         }
 
         public override void Load() {
+            Everest.Events.AssetReload.OnBeforeReload+= setRNGSeed;
             IL.Celeste.FinalBoss.CanChangeMusic += modCanChangeMusic;
             On.Celeste.Level.LoadLevel += modLoadLevel;
             On.Celeste.Level.TransitionRoutine += modTransitionRoutine;
             IL.Celeste.FinalBoss.ctor_Vector2_Vector2Array_int_float_bool_bool_bool += modBadelineBossConstructor;
+            SetRandomSeed(GetVariantValue<int>(Variant.SetSeed));
         }
 
         public override void Unload() {
@@ -39,6 +41,11 @@ namespace ExtendedVariants.Variants {
             On.Celeste.Level.LoadLevel -= modLoadLevel;
             On.Celeste.Level.TransitionRoutine -= modTransitionRoutine;
             IL.Celeste.FinalBoss.ctor_Vector2_Vector2Array_int_float_bool_bool_bool -= modBadelineBossConstructor;
+        }
+
+        private void setRNGSeed(bool silent) {
+            int seed = GetVariantValue<int>(Variant.SetSeed);
+            SetRandomSeed(seed);
         }
 
         private static void modLoadLevel(On.Celeste.Level.orig_LoadLevel orig, Level self, Player.IntroTypes playerIntro, bool isFromLoader) {

--- a/Variants/SetSeed.cs
+++ b/Variants/SetSeed.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace ExtendedVariants.Variants {
+    public class SetSeed : AbstractExtendedVariant {
+        public SetSeed() : base(variantType: typeof(int), defaultVariantValue: 0) { }
+
+        public override object ConvertLegacyVariantValue(int value) {
+            return value;
+        }
+    }
+}

--- a/Variants/WindEverywhere.cs
+++ b/Variants/WindEverywhere.cs
@@ -11,6 +11,7 @@ using static ExtendedVariants.Module.ExtendedVariantsModule;
 namespace ExtendedVariants.Variants {
     public class WindEverywhere : AbstractExtendedVariant {
 
+        private static Random randomGenerator = new Random();
 
         private static bool snowBackdropAddedByEVM = false;
 
@@ -42,7 +43,7 @@ namespace ExtendedVariants.Variants {
         }
 
         public override void SetRandomSeed(int seed) {
-            Calc.PushRandom(seed);
+            randomGenerator = new Random(seed);
         }
 
         public override void Load() {

--- a/Variants/WindEverywhere.cs
+++ b/Variants/WindEverywhere.cs
@@ -47,12 +47,12 @@ namespace ExtendedVariants.Variants {
         }
 
         public override void Load() {
+            Everest.Events.LevelLoader.OnLoadingThread += setRNGSeed;
             On.Celeste.Level.LoadLevel += modLoadLevel;
             On.Celeste.Level.TransitionRoutine += modTransitionRoutine;
             Everest.Events.Level.OnExit += onLevelExit;
 
             IL.Celeste.Wire.Render += onWireRender;
-            SetRandomSeed(GetVariantValue<int>(Variant.SetSeed));
         }
 
         public override void Unload() {
@@ -69,6 +69,11 @@ namespace ExtendedVariants.Variants {
                 snowBackdropAddedByEVM = false;
                 level.Foreground.Backdrops.RemoveAll(backdrop => backdrop.GetType() == typeof(ExtendedVariantWindSnowFG));
             }
+        }
+
+        private void setRNGSeed(Level level) {
+            int seed = GetVariantValue<int>(Variant.SetSeed);
+            SetRandomSeed(seed);
         }
 
         private static void modLoadLevel(On.Celeste.Level.orig_LoadLevel orig, Level self, Player.IntroTypes playerIntro, bool isFromLoader) {

--- a/Variants/WindEverywhere.cs
+++ b/Variants/WindEverywhere.cs
@@ -52,6 +52,7 @@ namespace ExtendedVariants.Variants {
             Everest.Events.Level.OnExit += onLevelExit;
 
             IL.Celeste.Wire.Render += onWireRender;
+            SetRandomSeed(GetVariantValue<int>(Variant.SetSeed));
         }
 
         public override void Unload() {

--- a/everest.yaml
+++ b/everest.yaml
@@ -1,5 +1,5 @@
 - Name: ExtendedVariantMode
-  Version: 0.50.5
+  Version: 0.50.6
   DLL: bin/ExtendedVariantMode.dll
   Dependencies:
     - Name: Everest


### PR DESCRIPTION
I reworked the functionality of RNG seeding. There's a new SetSeed class, which can be called from the console with an integer value. The Variants AddSeeker, BadelineBossesEverywhere and WindEverywhere have been updated to use read the seed value, when A level is loaded.